### PR TITLE
Ignore Eclipse project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 tags
 *.vim
 
+# Eclipse project files
+.project
+.settings


### PR DESCRIPTION
Simplification for developers using the [Eclipse IDE](https://eclipse.org/ide/).