### PR TITLE
Add 'craft_guide' as optional dependency:

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -1,3 +1,4 @@
 default
 wool
 dye
+craft_guide?


### PR DESCRIPTION
Adds compatibility with [cornernote's *craft_guide* mod](http://cornernote.github.io/minetest-craft_guide/) to ensure that craft recipes are registered.