### PR TITLE
Use 'mesecons_piston' in craft recipe

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -1,3 +1,4 @@
 default
 wool
 dye
+mesecons_pistons

--- a/init.lua
+++ b/init.lua
@@ -51,7 +51,7 @@ hover:register_hovercraft("hovercraft:hover_yellow" ,{
 minetest.register_craft({
 	output = 'hovercraft:hover_red',
 	recipe = {
-		{'', '', 'default:steelblock'},
+		{'', 'mesecons:piston', 'default:steelblock'},
 		{'wool:red', 'wool:red', 'wool:red'},
 		{'wool:black', 'wool:black', 'wool:black'},
 	}
@@ -60,7 +60,7 @@ minetest.register_craft({
 minetest.register_craft({
 	output = 'hovercraft:hover_blue',
 	recipe = {
-		{'', '', 'default:steelblock'},
+		{'', 'mesecons:piston', 'default:steelblock'},
 		{'wool:blue', 'wool:blue', 'wool:blue'},
 		{'wool:black', 'wool:black', 'wool:black'},
 	}
@@ -69,7 +69,7 @@ minetest.register_craft({
 minetest.register_craft({
 	output = 'hovercraft:hover_green',
 	recipe = {
-		{'', '', 'default:steelblock'},
+		{'', 'mesecons:piston', 'default:steelblock'},
 		{'wool:green', 'wool:green', 'wool:green'},
 		{'wool:black', 'wool:black', 'wool:black'},
 	}
@@ -78,7 +78,7 @@ minetest.register_craft({
 minetest.register_craft({
 	output = 'hovercraft:hover_yellow',
 	recipe = {
-		{'', '', 'default:steelblock'},
+		{'', 'mesecons:piston', 'default:steelblock'},
 		{'wool:yellow', 'wool:yellow', 'wool:yellow'},
 		{'wool:black', 'wool:black', 'wool:black'},
 	}


### PR DESCRIPTION
Just a suggestion to make the hovercraft's craft recipe a little more complex:

Adds 'mesecons:piston' to the craft recipe.