### PR TITLE
Option to Make Hovercrafts Ownable

### DIFF
--- a/hover.lua
+++ b/hover.lua
@@ -118,7 +118,7 @@ function hover:register_hovercraft(name, def)
 			end
 			local pos = self.object:getpos()
 			if self.timer > 0.5 then
-				local node = minetest.env:get_node({x=pos.x, y=pos.y-0.5, z=pos.z})
+				local node = minetest.get_node({x=pos.x, y=pos.y-0.5, z=pos.z})
 				if node.name == "air" or node.name == "ignore" then
 					self.velocity.y = 0 - self.fall_velocity
 				else
@@ -167,7 +167,7 @@ function hover:register_hovercraft(name, def)
 				return
 			end
 			pointed_thing.under.y = pointed_thing.under.y + 0.5
-			minetest.env:add_entity(pointed_thing.under, name)
+			minetest.add_entity(pointed_thing.under, name)
 			itemstack:take_item()
 			return itemstack
 		end,

--- a/hover.lua
+++ b/hover.lua
@@ -53,7 +53,13 @@ function hover:register_hovercraft(name, def)
 				clicker:set_detach()
 			elseif not self.player then
 				self.player = clicker
-				clicker:set_attach(self.object, "", {x=-2,y=16.5,z=0}, {x=0,y=90,z=0})
+
+				local attach_y = 16.5
+				if core.features.object_independent_selectionbox then
+					attach_y = 5.75
+				end
+
+				clicker:set_attach(self.object, "", {x=-2,y=attach_y,z=0}, {x=0,y=90,z=0})
 				clicker:set_animation({x=81, y=81})
 				local yaw = clicker:get_look_horizontal()
 				self.object:set_yaw(yaw)
@@ -68,7 +74,11 @@ function hover:register_hovercraft(name, def)
 		on_step = function(self, dtime)
 			self.timer = self.timer + dtime
 			if self.player then
-				local yaw = self.player:get_look_horizontal()
+				local yaw = nil
+				local p_look = self.player:get_look_horizontal()
+				if p_look then
+					yaw = p_look + math.rad(90)
+				end
 				if not yaw then
 					return
 				end

--- a/hover.lua
+++ b/hover.lua
@@ -41,7 +41,7 @@ function hover:register_hovercraft(name, def)
 			end
 			local pos = self.object:get_pos()
 			if self.player and clicker == self.player then
-				if self.sound then					
+				if self.sound then
 					minetest.sound_stop(self.sound)
 					minetest.sound_play("hovercraft_thrust_fade", {object = self.object})
 					self.sound = nil
@@ -111,7 +111,7 @@ function hover:register_hovercraft(name, def)
 					self.velocity.y = self.jump_velocity
 					self.timer = 0
 					minetest.sound_play("hovercraft_jump", {object = self.object})
-				end	
+				end
 				if ctrl.sneak then
 					self.player:set_animation({x=81, y=81})
 				end
@@ -155,13 +155,13 @@ function hover:register_hovercraft(name, def)
 					self.velocity.z = 0
 				end
 			end
-			self.object:set_velocity(self.velocity)	
+			self.object:set_velocity(self.velocity)
 		end,
 	})
 	minetest.register_craftitem(name, {
 		description = def.description,
 		inventory_image = def.inventory_image,
-		liquids_pointable = true,	
+		liquids_pointable = true,
 		on_place = function(itemstack, placer, pointed_thing)
 			if pointed_thing.type ~= "node" then
 				return

--- a/hover.lua
+++ b/hover.lua
@@ -23,7 +23,9 @@ function hover:register_hovercraft(name, def)
 			self.object:set_animation({x=0, y=24}, 30)
 
 			local sdata = minetest.deserialize(staticdata)
-			self.owner = sdata.owner
+			if sdata then
+				self.owner = sdata.owner
+			end
 		end,
 		on_punch = function(self, puncher, time_from_last_punch, tool_capabilities, dir)
 			if not puncher or not puncher:is_player() then return end

--- a/hover.lua
+++ b/hover.lua
@@ -1,4 +1,3 @@
-hover = {}
 
 function hover:register_hovercraft(name, def)
 	minetest.register_entity(name, {
@@ -22,6 +21,9 @@ function hover:register_hovercraft(name, def)
 		on_activate = function(self, staticdata, dtime_s)
 			self.object:set_armor_groups({immortal=1})
 			self.object:set_animation({x=0, y=24}, 30)
+
+			local sdata = minetest.deserialize(staticdata)
+			self.owner = sdata.owner
 		end,
 		on_punch = function(self, puncher, time_from_last_punch, tool_capabilities, dir)
 			if not puncher or not puncher:is_player() then return end
@@ -31,6 +33,11 @@ function hover:register_hovercraft(name, def)
 			end
 
 			local pname = puncher:get_player_name()
+			if hover.ownable and self.owner and pname ~= self.owner then
+				minetest.chat_send_player(pname, "You cannot take " .. self.owner .. "'s hovercraft.")
+				return
+			end
+
 			local stack = ItemStack(name)
 			local pinv = puncher:get_inventory()
 			if not pinv:room_for_item("main", stack) then
@@ -48,6 +55,7 @@ function hover:register_hovercraft(name, def)
 			if not clicker or not clicker:is_player() then
 				return
 			end
+
 			local pos = self.object:get_pos()
 			if self.player and clicker == self.player then
 				if self.sound then
@@ -61,6 +69,12 @@ function hover:register_hovercraft(name, def)
 				clicker:set_animation({x=0, y=0})
 				clicker:set_detach()
 			elseif not self.player then
+				local pname = clicker:get_player_name()
+				if hover.ownable and self.owner and pname ~= self.owner then
+					minetest.chat_send_player(pname, "You cannot ride " .. self.owner .. "'s hovercraft.")
+					return
+				end
+
 				self.player = clicker
 
 				local attach_y = 16.5
@@ -176,7 +190,16 @@ function hover:register_hovercraft(name, def)
 			end
 			self.object:set_velocity(self.velocity)
 		end,
+
+		get_staticdata = function(self)
+			local sdata = {
+				owner = self.owner,
+			}
+
+			return minetest.serialize(sdata)
+		end,
 	})
+
 	minetest.register_craftitem(name, {
 		description = def.description,
 		inventory_image = def.inventory_image,
@@ -186,7 +209,7 @@ function hover:register_hovercraft(name, def)
 				return
 			end
 			pointed_thing.under.y = pointed_thing.under.y + 0.5
-			minetest.add_entity(pointed_thing.under, name)
+			minetest.add_entity(pointed_thing.under, name, minetest.serialize({owner=placer:get_player_name()}))
 			itemstack:take_item()
 			return itemstack
 		end,

--- a/hover.lua
+++ b/hover.lua
@@ -24,16 +24,25 @@ function hover:register_hovercraft(name, def)
 			self.object:set_animation({x=0, y=24}, 30)
 		end,
 		on_punch = function(self, puncher, time_from_last_punch, tool_capabilities, dir)
+			if not puncher or not puncher:is_player() then return end
+
 			if self.player then
 				return
 			end
+
+			local pname = puncher:get_player_name()
+			local stack = ItemStack(name)
+			local pinv = puncher:get_inventory()
+			if not pinv:room_for_item("main", stack) then
+				minetest.chat_send_player(pname, "You don't have room in your inventory.")
+				return
+			end
+
 			if self.sound then
 				minetest.sound_stop(self.sound)
 			end
 			self.object:remove()
-			if puncher and puncher:is_player() then
-				puncher:get_inventory():add_item("main", name)
-			end
+			pinv:add_item("main", stack)
 		end,
 		on_rightclick = function(self, clicker)
 			if not clicker or not clicker:is_player() then

--- a/hover.lua
+++ b/hover.lua
@@ -39,7 +39,7 @@ function hover:register_hovercraft(name, def)
 			if not clicker or not clicker:is_player() then
 				return
 			end
-			local pos = self.object:getpos()
+			local pos = self.object:get_pos()
 			if self.player and clicker == self.player then
 				if self.sound then					
 					minetest.sound_stop(self.sound)
@@ -55,24 +55,24 @@ function hover:register_hovercraft(name, def)
 				self.player = clicker
 				clicker:set_attach(self.object, "", {x=-2,y=16.5,z=0}, {x=0,y=90,z=0})
 				clicker:set_animation({x=81, y=81})
-				local yaw = clicker:get_look_yaw()
-				self.object:setyaw(yaw)
+				local yaw = clicker:get_look_horizontal()
+				self.object:set_yaw(yaw)
 				self.yaw = yaw
 				pos.y = pos.y + 0.5
 				minetest.sound_play("hovercraft_jump", {object = self.object})
 				self.object:set_animation({x=0, y=0})
 			end
 			self.last_pos = vector.new(pos)
-			self.object:setpos(pos)
+			self.object:set_pos(pos)
 		end,
 		on_step = function(self, dtime)
 			self.timer = self.timer + dtime
 			if self.player then
-				local yaw = self.player:get_look_yaw()
+				local yaw = self.player:get_look_horizontal()
 				if not yaw then
 					return
 				end
-				self.object:setyaw(yaw)
+				self.object:set_yaw(yaw)
 				local ctrl = self.player:get_player_control()
 				if ctrl.up then
 					if self.thrust < self.max_speed then
@@ -116,7 +116,7 @@ function hover:register_hovercraft(name, def)
 					self.player:set_animation({x=81, y=81})
 				end
 			end
-			local pos = self.object:getpos()
+			local pos = self.object:get_pos()
 			if self.timer > 0.5 then
 				local node = minetest.get_node({x=pos.x, y=pos.y-0.5, z=pos.z})
 				if node.name == "air" or node.name == "ignore" then
@@ -124,7 +124,7 @@ function hover:register_hovercraft(name, def)
 				else
 					self.velocity.y = 0
 					pos.y = math.floor(pos.y) + 0.5
-					self.object:setpos(pos)
+					self.object:set_pos(pos)
 				end
 				self.timer = 0
 			end
@@ -155,7 +155,7 @@ function hover:register_hovercraft(name, def)
 					self.velocity.z = 0
 				end
 			end
-			self.object:setvelocity(self.velocity)	
+			self.object:set_velocity(self.velocity)	
 		end,
 	})
 	minetest.register_craftitem(name, {

--- a/init.lua
+++ b/init.lua
@@ -1,4 +1,10 @@
-dofile(minetest.get_modpath("hovercraft").."/hover.lua")
+
+hover = {}
+hover.modname = core.get_current_modname()
+hover.modpath = core.get_modpath(hover.modname)
+
+dofile(hover.modpath .. "/settings.lua")
+dofile(hover.modpath .. "/hover.lua")
 
 hover:register_hovercraft("hovercraft:hover_red" ,{
 	description = "Red Hovercraft",

--- a/mod.conf
+++ b/mod.conf
@@ -1,0 +1,1 @@
+name = hovercraft

--- a/mod.conf
+++ b/mod.conf
@@ -1,1 +1,4 @@
 name = hovercraft
+description = A fun alternative mode of transport.
+author = Stuart Jones (stu)
+depends = default, wool, dye

--- a/settings.lua
+++ b/settings.lua
@@ -1,0 +1,2 @@
+
+hover.ownable = core.settings:get_bool("mount_ownable", true)

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,0 +1,3 @@
+
+# Hovercrafts can only be used by owners.
+mount_ownable (Ownable hovercrafts) bool true


### PR DESCRIPTION
Closes: #5

Does the following:
- uses setting `mount_ownable` to determine if hovercrafts can be ridden or picked up by other players
- checks that there is room in the player's inventory before trying to pick up
- fixes attached horizontal view for newer Minetest versions (perhaps this should be backwards compatible?)
- adds `mod.conf`
- replaces deprecated `get*`/`set*` methods with `get_*`/`set_*`
- replaces deprecated calls to `minetest.env`